### PR TITLE
In debug code, don't try to dereference a non-pointer.

### DIFF
--- a/src/Slicing/FunctionStaticSlicer.cpp
+++ b/src/Slicing/FunctionStaticSlicer.cpp
@@ -524,7 +524,7 @@ bool FunctionStaticSlicer::slice() {
     if (ii->isSliced() && canSlice(i)) {
 #ifdef DEBUG_SLICE
       errs() << "  removing:";
-      i->print(errs());
+      i.print(errs());
       errs() << " from " << i.getParent()->getName() << '\n';
 #endif
       i.replaceAllUsesWith(UndefValue::get(i.getType()));


### PR DESCRIPTION
This is a simple, obviously-correct fix.
