### PR TITLE
Use standard C++ headers and namespaces instead of Boost and std::tr1.

### DIFF
--- a/src/PointsTo/AlgoAndersen.cpp
+++ b/src/PointsTo/AlgoAndersen.cpp
@@ -1,7 +1,7 @@
 // This file is distributed under the University of Illinois Open Source
 // License. See LICENSE.TXT for details.
 
-#include <boost/tr1/functional.hpp>
+#include <functional>
 
 #include "AlgoAndersen.h"
 #include "Fixpoint.h"
@@ -33,8 +33,8 @@ RuleFunction<ANDERSEN>::Type getRuleFunction(ASSIGNMENT<
 	    return old_size != L.size();
 	}
     };
-    using std::tr1::bind;
-    using std::tr1::placeholders::_1;
+    using std::bind;
+    using std::placeholders::_1;
     return bind(&local::function,_1,
 		E.getArgument1().getArgument(),
 		E.getArgument2().getArgument());
@@ -58,8 +58,8 @@ RuleFunction<ANDERSEN>::Type getRuleFunction(ASSIGNMENT<
 	    return old_size != L.size();
 	}
     };
-    using std::tr1::bind;
-    using std::tr1::placeholders::_1;
+    using std::bind;
+    using std::placeholders::_1;
     return bind(&local::function,_1,
 		E.getArgument1().getArgument(),
 		E.getArgument2().getArgument().getArgument());
@@ -86,8 +86,8 @@ RuleFunction<ANDERSEN>::Type getRuleFunction(ASSIGNMENT<
 	    return old_size != L.size();
 	}
     };
-    using std::tr1::bind;
-    using std::tr1::placeholders::_1;
+    using std::bind;
+    using std::placeholders::_1;
     return bind(&local::function,_1,
 		E.getArgument1().getArgument(),
 		E.getArgument2().getArgument().getArgument());
@@ -116,8 +116,8 @@ RuleFunction<ANDERSEN>::Type getRuleFunction(ASSIGNMENT<
 	    return change;
 	}
     };
-    using std::tr1::bind;
-    using std::tr1::placeholders::_1;
+    using std::bind;
+    using std::placeholders::_1;
     return bind(&local::function,_1,
 		E.getArgument1().getArgument().getArgument(),
 		E.getArgument2().getArgument());
@@ -150,8 +150,8 @@ RuleFunction<ANDERSEN>::Type getRuleFunction(ASSIGNMENT<
 	    return change;
 	}
     };
-    using std::tr1::bind;
-    using std::tr1::placeholders::_1;
+    using std::bind;
+    using std::placeholders::_1;
     return bind(&local::function,_1,
 		E.getArgument1().getArgument().getArgument(),
 		E.getArgument2().getArgument().getArgument());
@@ -179,8 +179,8 @@ RuleFunction<ANDERSEN>::Type getRuleFunction(ASSIGNMENT<
 	    return change;
 	}
     };
-    using std::tr1::bind;
-    using std::tr1::placeholders::_1;
+    using std::bind;
+    using std::placeholders::_1;
     return bind(&local::function,_1,
 		E.getArgument1().getArgument().getArgument(),
 		E.getArgument2().getArgument().getArgument());
@@ -204,8 +204,8 @@ RuleFunction<ANDERSEN>::Type getRuleFunction(ASSIGNMENT<
 	    return old_size != L.size();
 	}
     };
-    using std::tr1::bind;
-    using std::tr1::placeholders::_1;
+    using std::bind;
+    using std::placeholders::_1;
     return bind(&local::function,_1,
 		E.getArgument1().getArgument(),
 		E.getArgument2().getArgument());
@@ -229,8 +229,8 @@ RuleFunction<ANDERSEN>::Type getRuleFunction(ASSIGNMENT<
 	    return old_size != L.size();
 	}
     };
-    using std::tr1::bind;
-    using std::tr1::placeholders::_1;
+    using std::bind;
+    using std::placeholders::_1;
     return bind(&local::function,_1,
 		E.getArgument1().getArgument(),
 		E.getArgument2().getArgument());
@@ -260,8 +260,8 @@ RuleFunction<ANDERSEN>::Type getRuleFunction(ASSIGNMENT<
 	    return change;
 	}
     };
-    using std::tr1::bind;
-    using std::tr1::placeholders::_1;
+    using std::bind;
+    using std::placeholders::_1;
     return bind(&local::function,_1,
 		E.getArgument1().getArgument().getArgument(),
 		E.getArgument2().getArgument());

--- a/src/PointsTo/PointsTo.h
+++ b/src/PointsTo/PointsTo.h
@@ -4,11 +4,10 @@
 #ifndef POINTSTO_POINTSTO_H
 #define POINTSTO_POINTSTO_H
 
+#include <functional>
 #include <map>
 #include <set>
 #include <vector>
-
-#include <boost/tr1/functional.hpp>
 
 #include "PredefContainers.h"
 #include "RuleExpressions.h"
@@ -38,7 +37,7 @@ namespace llvm { namespace ptr {
 
   template<typename PointsToAlgorithm>
   struct RuleFunction {
-      typedef std::tr1::function<bool(typename PointsToSets<PointsToAlgorithm>::Type&)>
+      typedef std::function<bool(typename PointsToSets<PointsToAlgorithm>::Type&)>
               Type;
 
       static inline bool


### PR DESCRIPTION
The Boost headers are especially problematic: they require RTTI, but LLVM is often built with RTTI explicitly disabled.

This all compiles fine using a sufficiently-modern compiler, such as gcc-4.4.6 with "-std=c++0x" or gcc-4.7.1 with "-std=c++11".
